### PR TITLE
itertools bug fixed on line 522 (with python 3.5.0)

### DIFF
--- a/code/thinkdsp.py
+++ b/code/thinkdsp.py
@@ -519,7 +519,7 @@ class Spectrogram:
 
         returns: sequence of float times in seconds
         """
-        ts = sorted(self.spec_map.iterkeys())
+        ts = sorted(iter(self.spec_map))
         return ts
 
     def frequencies(self):


### PR DESCRIPTION
notebooks didn't work when I tried your examples and it referred to iterkeys.