### PR TITLE
Update chap02

### DIFF
--- a/code/chap02.ipynb
+++ b/code/chap02.ipynb
@@ -447,7 +447,7 @@
    "source": [
     "## Amplitude and phase\n",
     "\n",
-    "Make a triangle wave."
+    "Make a sawtooth wave."
    ]
   },
   {
@@ -691,6 +691,7 @@
    "outputs": [],
    "source": [
     "i = complex(0, 1)\n",
+    "spectrum = wave.make_spectrum()\n",
     "spectrum.hs = magnitude * np.exp(i * angle)"
    ]
   },


### PR DESCRIPTION
The first line edited is self explanatory, that is a typo. If we create a sawtooth signal, we should say "sawtooth" instead of "triangle"

The second edit is needed, since the spectrum that we are modifying is from line 440, which is before creating the new sawtooth signal. 
I discovered it by making changes to duration and framerate of the sawtooth signal, and when playing the two comparative audios (with just different phases) the lenghts of the audios were completely different.