### PR TITLE
Fix dockerfile for mybinder.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL workdir.launchbot.io="/usr/workdir"
 LABEL 8888.port.launchbot.io="Jupyter Notebook"
 
 # Set the working directory
-WORKDIR /usr/workdir
+ENV WORKDIR /usr/workdir
+WORKDIR ${WORKDIR}
 COPY code ${WORKDIR}
 RUN chown -R ${NB_USER} ${WORKDIR}
 USER ${NB_USER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ LABEL 8888.port.launchbot.io="Jupyter Notebook"
 
 # Set the working directory
 WORKDIR /usr/workdir
-COPY . /usr/workdir
+COPY code ${WORKDIR}
+RUN chown -R ${NB_USER} ${WORKDIR}
+USER ${NB_USER}
 
 # Expose the notebook port
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL workdir.launchbot.io="/usr/workdir"
 LABEL 8888.port.launchbot.io="Jupyter Notebook"
 
 # Set the working directory
+USER root
 ENV WORKDIR /usr/workdir
 WORKDIR ${WORKDIR}
 COPY code ${WORKDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL 8888.port.launchbot.io="Jupyter Notebook"
 
 # Set the working directory
 WORKDIR /usr/workdir
+COPY . /usr/workdir
 
 # Expose the notebook port
 EXPOSE 8888


### PR DESCRIPTION
Previously, if we tried to launch mybinder.org from the repo as suggested in the book we will find that we get an empty work directory.

This PR fix that issue.