### PR TITLE
solving "make_spectrogram" bug

### DIFF
--- a/code/thinkdsp.py
+++ b/code/thinkdsp.py
@@ -934,7 +934,7 @@ class Wave:
         if win_flag:
             window = np.hamming(seg_length)
         i, j = 0, seg_length
-        step = seg_length // 2
+        step = int(seg_length // 2)
 
         # map from time to Spectrum
         spec_map = {}


### PR DESCRIPTION
**Bug Description**: np.ndarray does not accept _float_ as values for indices [ step = seg_length // 2 ] thus the make_spectrogram function doesn't work.
**Solution**: solving this issue by ensuring **step** is an _integer_ [ step = int(seg_length // 2) ] thereby the values of i and j are also integers.