### PR TITLE
Add pytest suite from v2 for code/thinkdsp.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROJECT_NAME = ThinkDSP
 PYTHON_VERSION = 3.10
 PYTHON_INTERPRETER = python
 
+.PHONY: create_environment requirements tests
 
 
 ## Set up Python environment
@@ -17,5 +18,7 @@ requirements:
 
 
 tests:
+	# Unit tests for code/thinkdsp.py (ported from v2 tests/test_thinkdsp.py)
+	pytest tests/
 	# looks like we can't test chapters with interactives
 	cd code; pytest --nbmake chap0[2346789].ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ scipy = "^1.5.4"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+# Point pytest at master's monolithic module in code/ (not v2's src/ package layout).
+[tool.pytest.ini_options]
+pythonpath = ["code"]
+testpaths = ["tests"]

--- a/tests/test_thinkdsp.py
+++ b/tests/test_thinkdsp.py
@@ -1,0 +1,102 @@
+"""This file contains code for use with "Think Stats",
+by Allen B. Downey, available from greenteapress.com
+
+Copyright 2014 Allen B. Downey
+License: GNU GPLv3 http://www.gnu.org/licenses/gpl.html
+"""
+
+import unittest
+import thinkdsp
+
+import numpy as np
+
+
+class Test(unittest.TestCase):
+    def assertArrayAlmostEqual(self, a, b):
+        total_error = np.sum(np.abs(a-b))
+        self.assertAlmostEqual(total_error, 0)
+
+    def testMakeSpectrum(self):
+        # rfft with n even
+        ys = np.arange(10)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum()
+        self.assertAlmostEqual(spectrum.hs[0], 45)
+        wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+        # rfft with n odd
+        ys = np.arange(11)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum()
+        self.assertAlmostEqual(spectrum.hs[0], 55)
+
+        # TODO: make rfft invertible when n is odd
+        #wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        #self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+        # fft with n even
+        ys = np.arange(10)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum(full=True)
+        self.assertAlmostEqual(spectrum.hs[0], 45)
+        wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+        # fft with n odd
+        ys = np.arange(11)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum(full=True)
+        self.assertAlmostEqual(spectrum.hs[0], 55)
+        wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+    def testComplexSinusoid(self):
+        signal = thinkdsp.ComplexSinusoid(440, 0.7, 1.1)
+        result = signal.evaluate(2.1) * complex(-1.5, -0.5)
+        self.assertAlmostEqual(result, -0.164353351475-1.09452637056j)
+
+    def testChirp(self):
+        signal = thinkdsp.Chirp(100, 200, 0.5)
+        result = signal.evaluate([1.001, 1.002, 1.005])
+        self.assertAlmostEqual(result[0], 0.5)
+        self.assertAlmostEqual(result[2], -0.49384417)
+
+    def testExpoChirp(self):
+        signal = thinkdsp.ExpoChirp(100, 200, 0.5)
+        result = signal.evaluate([0, 0.001, 0.002])
+        self.assertAlmostEqual(result[0], 0.5)
+        self.assertAlmostEqual(result[2], -0.27167286)
+
+    def testWaveAdd(self):
+        ys = np.array([1, 2, 3, 4])
+        wave1 = thinkdsp.Wave(ys, framerate=1)
+        wave2 = wave1.copy()
+        wave2.shift(2)
+        wave = wave1 + wave2
+
+        self.assertEqual(len(wave), 6)
+        self.assertAlmostEqual(sum(wave.ys), 20)
+
+    def testDct(self):
+        signal = thinkdsp.CosSignal(freq=2)
+        wave = signal.make_wave(duration=1, framerate=8)
+        dct = wave.make_dct()
+
+        self.assertAlmostEqual(dct.fs[0], 0.25)
+
+    def testImpulses(self):
+        imp_sig = thinkdsp.Impulses([0.01, 0.4, 0.8, 1.2],
+                                    amps=[1, 0.5, 0.25, 0.1])
+        impulses = imp_sig.make_wave(start=0, duration=1.3,
+                                     framerate=11025)
+
+        self.assertEqual(len(impulses), 14332)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ports the unit-test suite from the `v2` branch onto `master` without adopting the `src/` package layout.

- Adds `tests/test_thinkdsp.py` (7 tests: chirp, complex sinusoid, DCT, expo chirp, impulses, spectrum, wave addition)
- Configures `pyproject.toml` so pytest imports the monolithic module from `code/` (`pythonpath = ["code"]`)
- Adds a `tests` target to the `Makefile` that runs `pytest tests/` before the existing notebook checks

This gives `master` a lightweight, dependency-minimal regression suite for `code/thinkdsp.py` while keeping the current repo structure intact.

## Changes

| File | Change |
|------|--------|
| `tests/test_thinkdsp.py` | New — brought from `v2` |
| `pyproject.toml` | `[tool.pytest.ini_options]` with `pythonpath = ["code"]` |
| `Makefile` | `tests` target runs `pytest tests/` first |

## Verification

On branch `add-pytest-suite-from-v2` (Python 3.12.3, pytest 9.0.3):

```bash
PYTHONPATH=code pytest tests/ -v
# 7 passed, 1 warning (IPython.display.Audio unavailable outside notebooks — expected)
```

```bash
pytest tests/   # via pyproject.toml pythonpath — also 7 passed
```

`make tests` runs the new unit-test block successfully; it may still fail on the pre-existing `pytest --nbmake` notebook step if `nbmake` is not installed (that path was already on `master` and is unrelated to this PR).

## Notes

- No changes to `code/thinkdsp.py` itself
- Tests exercise synthetically generated signals only (no audio fixtures required)
- Opened as a draft for maintainer review before merge