### PR TITLE
Add pytest suite from v2 for master's code/thinkdsp.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,7 @@ requirements:
 
 
 tests:
+	# Unit tests for code/thinkdsp.py (ported from v2 tests/test_thinkdsp.py)
+	pytest tests/
 	# looks like we can't test chapters with interactives
 	cd code; pytest --nbmake chap0[2346789].ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ scipy = "^1.5.4"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+# Point pytest at master's monolithic module in code/ (not v2's src/ package layout).
+[tool.pytest.ini_options]
+pythonpath = ["code"]
+testpaths = ["tests"]

--- a/tests/test_thinkdsp.py
+++ b/tests/test_thinkdsp.py
@@ -1,0 +1,102 @@
+"""This file contains code for use with "Think Stats",
+by Allen B. Downey, available from greenteapress.com
+
+Copyright 2014 Allen B. Downey
+License: GNU GPLv3 http://www.gnu.org/licenses/gpl.html
+"""
+
+import unittest
+import thinkdsp
+
+import numpy as np
+
+
+class Test(unittest.TestCase):
+    def assertArrayAlmostEqual(self, a, b):
+        total_error = np.sum(np.abs(a-b))
+        self.assertAlmostEqual(total_error, 0)
+
+    def testMakeSpectrum(self):
+        # rfft with n even
+        ys = np.arange(10)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum()
+        self.assertAlmostEqual(spectrum.hs[0], 45)
+        wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+        # rfft with n odd
+        ys = np.arange(11)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum()
+        self.assertAlmostEqual(spectrum.hs[0], 55)
+
+        # TODO: make rfft invertible when n is odd
+        #wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        #self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+        # fft with n even
+        ys = np.arange(10)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum(full=True)
+        self.assertAlmostEqual(spectrum.hs[0], 45)
+        wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+        # fft with n odd
+        ys = np.arange(11)
+        wave = thinkdsp.Wave(ys, framerate=10)
+        spectrum = wave.make_spectrum(full=True)
+        self.assertAlmostEqual(spectrum.hs[0], 55)
+        wave2 = spectrum.make_wave()
+        #print(wave2.ys)
+        self.assertArrayAlmostEqual(wave.ys, wave2.ys)
+
+    def testComplexSinusoid(self):
+        signal = thinkdsp.ComplexSinusoid(440, 0.7, 1.1)
+        result = signal.evaluate(2.1) * complex(-1.5, -0.5)
+        self.assertAlmostEqual(result, -0.164353351475-1.09452637056j)
+
+    def testChirp(self):
+        signal = thinkdsp.Chirp(100, 200, 0.5)
+        result = signal.evaluate([1.001, 1.002, 1.005])
+        self.assertAlmostEqual(result[0], 0.5)
+        self.assertAlmostEqual(result[2], -0.49384417)
+
+    def testExpoChirp(self):
+        signal = thinkdsp.ExpoChirp(100, 200, 0.5)
+        result = signal.evaluate([0, 0.001, 0.002])
+        self.assertAlmostEqual(result[0], 0.5)
+        self.assertAlmostEqual(result[2], -0.27167286)
+
+    def testWaveAdd(self):
+        ys = np.array([1, 2, 3, 4])
+        wave1 = thinkdsp.Wave(ys, framerate=1)
+        wave2 = wave1.copy()
+        wave2.shift(2)
+        wave = wave1 + wave2
+
+        self.assertEqual(len(wave), 6)
+        self.assertAlmostEqual(sum(wave.ys), 20)
+
+    def testDct(self):
+        signal = thinkdsp.CosSignal(freq=2)
+        wave = signal.make_wave(duration=1, framerate=8)
+        dct = wave.make_dct()
+
+        self.assertAlmostEqual(dct.fs[0], 0.25)
+
+    def testImpulses(self):
+        imp_sig = thinkdsp.Impulses([0.01, 0.4, 0.8, 1.2],
+                                    amps=[1, 0.5, 0.25, 0.1])
+        impulses = imp_sig.make_wave(start=0, duration=1.3,
+                                     framerate=11025)
+
+        self.assertEqual(len(impulses), 14332)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Brings the pytest suite from the `v2` branch onto `master` without adopting v2's `src/` package restructure. The suite exercises the existing monolithic `code/thinkdsp.py`.

### Changes

| File | Change |
|------|--------|
| `tests/test_thinkdsp.py` | Ported from `v2` (`origin/v2:tests/test_thinkdsp.py`) — 7 unittest cases covering spectrum, sinusoids, chirps, wave add, DCT, and impulses |
| `pyproject.toml` | Point pytest `pythonpath` at `code/` so imports resolve against master's module layout |
| `Makefile` | Wire `make tests` to run `pytest tests/` (before the existing notebook tests) |

**Not included** (intentionally): v2's `src/thinkdsp/` layout, poetry/packaging changes, or other v2-only restructure.

### Coverage (unchanged from v2 / old `code/thinkdsp_test.py`)

- `testMakeSpectrum` — rfft/fft even & odd lengths, invertibility
- `testComplexSinusoid`
- `testChirp` / `testExpoChirp`
- `testWaveAdd`
- `testDct`
- `testImpulses`

## Test plan / verification

- [x] `pytest tests/` — all tests pass against master's `code/thinkdsp.py`
- [x] `make tests` invokes the new unit suite (plus existing notebook tests target)
- [x] No modifications to `code/thinkdsp.py` itself

Branch: `citax:bring-pytest-suite-from-v2` → `AllenDowney/ThinkDSP:master` (draft)
